### PR TITLE
Standalone versions for Mac and Linux

### DIFF
--- a/Resources/qt.conf
+++ b/Resources/qt.conf
@@ -1,0 +1,4 @@
+[Paths]
+Prefix=Qt
+Plugins=plugins
+

--- a/Resources/qtconf.qrc
+++ b/Resources/qtconf.qrc
@@ -1,0 +1,5 @@
+<RCC>
+    <qresource prefix="/qt/etc">
+        <file>qt.conf</file>
+    </qresource>
+</RCC>

--- a/cpp/mountainview/src/mountainview.pro
+++ b/cpp/mountainview/src/mountainview.pro
@@ -6,6 +6,8 @@ QMAKE_CXXFLAGS += -Wno-reorder #qaccordion
 # CONFIG += openmp ## removed open by jfm 5/18/2018
 CONFIG += mlcommon mvcommon taskprogress
 
+standalone:unix:!macx:CONFIG += ml_qtdeploylinux
+
 DESTDIR = ../bin
 OBJECTS_DIR = ../build
 MOC_DIR=../build
@@ -180,3 +182,4 @@ DISTFILES += \
 
 
 include(../../../cpp/installbin.pri)
+

--- a/cpp/mountainview/src/mountainview.pro
+++ b/cpp/mountainview/src/mountainview.pro
@@ -12,6 +12,14 @@ MOC_DIR=../build
 TARGET = qt-mountainview
 TEMPLATE = app
 
+macx{
+    standalone: {
+        CONFIG += app_bundle
+    } else {
+        CONFIG -= app_bundle
+    }
+}
+
 RESOURCES += mountainview.qrc
 
 INCLUDEPATH += msv/plugins msv/views

--- a/cpp/mountainview/src/mountainview.pro
+++ b/cpp/mountainview/src/mountainview.pro
@@ -12,20 +12,21 @@ MOC_DIR=../build
 TARGET = qt-mountainview
 TEMPLATE = app
 
+target.path = $$ML_BINDIR
+
 macx{
     standalone: {
         CONFIG += app_bundle
     } else {
         CONFIG -= app_bundle
     }
-} else {
-    standalone: {
-        CONFIG += ml_qtdeploylinux
-        ML_BINDIR=$${ML_BINDIR_STANDALONE}
-    }
 }
 
-target.path = $$ML_BINDIR
+linux:standalone: {
+    CONFIG += ml_qtdeploylinux
+    target.path = $${ML_BINDIR_STANDALONE}
+}
+
 INSTALLS += target
 
 RESOURCES += mountainview.qrc

--- a/cpp/mountainview/src/mountainview.pro
+++ b/cpp/mountainview/src/mountainview.pro
@@ -180,6 +180,5 @@ FORMS += \
 DISTFILES += \
     msv/views/curationprogram.js
 
-
-include(../../../cpp/installbin.pri)
-
+target.path = $$ML_BINDIR
+INSTALLS += target

--- a/cpp/mountainview/src/mountainview.pro
+++ b/cpp/mountainview/src/mountainview.pro
@@ -6,8 +6,6 @@ QMAKE_CXXFLAGS += -Wno-reorder #qaccordion
 # CONFIG += openmp ## removed open by jfm 5/18/2018
 CONFIG += mlcommon mvcommon taskprogress
 
-standalone:unix:!macx:CONFIG += ml_qtdeploylinux
-
 DESTDIR = ../bin
 OBJECTS_DIR = ../build
 MOC_DIR=../build
@@ -20,7 +18,15 @@ macx{
     } else {
         CONFIG -= app_bundle
     }
+} else {
+    standalone: {
+        CONFIG += ml_qtdeploylinux
+        ML_BINDIR=$${ML_BINDIR_STANDALONE}
+    }
 }
+
+target.path = $$ML_BINDIR
+INSTALLS += target
 
 RESOURCES += mountainview.qrc
 
@@ -179,6 +185,3 @@ FORMS += \
 
 DISTFILES += \
     msv/views/curationprogram.js
-
-target.path = $$ML_BINDIR
-INSTALLS += target

--- a/cpp/mountainview/src/mountainviewmain.cpp
+++ b/cpp/mountainview/src/mountainviewmain.cpp
@@ -195,6 +195,9 @@ int main(int argc, char* argv[])
     CounterManager* counterManager = new CounterManager;
     registry.addAutoReleasedObject(counterManager);
 
+    qDebug().noquote() << QString("** qt-mountainview ; origin: %1 ; commit: %2").arg(GIT_ORIGIN).arg(GIT_COMMIT);
+    qDebug().noquote() << QString("** %1").arg(COMPILE_INFO);
+
     //The process manager
     QProcessManager* processManager = new QProcessManager;
     registry.addAutoReleasedObject(processManager);
@@ -266,7 +269,6 @@ int main(int argc, char* argv[])
         channel_colors << QColor(brighten(color_strings[i], 80));
 
     QList<QColor> label_colors = generate_colors_ahb();
-
     QString mv_fname;
     if (CLP.unnamed_parameters.value(0).endsWith(".mv")) {
         mv_fname = CLP.unnamed_parameters.value(0);

--- a/features/ml_config.prf
+++ b/features/ml_config.prf
@@ -7,7 +7,30 @@ ML_BINDIR=$${ML_DIR}/bin
 ML_PACKAGESDIR=$${ML_DIR}/packages
 ML_KRONDIR=$${ML_DIR}/kron
 
+# Store git commit/repo origin/compile info in preprocessor directives.
+GIT_COMMIT_COMMAND = git --git-dir $$system_quote($$system_path($$ML_DIR/.git)) \
+--work-tree $$system_quote($$system_path($$ML_DIR/)) describe --always --all \
+--tags --long
+
+GIT_COMMIT = $$system($$GIT_COMMIT_COMMAND)
+DEFINES += "GIT_COMMIT=\"\\\"$$GIT_COMMIT\\\"\""
+
+# Store git commit/repo origin/compile info in preprocessor directives.
+GIT_HASH_COMMAND = git --git-dir $$system_quote($$system_path($$ML_DIR/.git)) \
+--work-tree $$system_quote($$system_path($$ML_DIR/)) rev-parse --short HEAD
+
+GIT_HASH= $$system($$GIT_HASH_COMMAND)
+DEFINES += "GIT_HASH=\"\\\"$$GIT_HASH\\\"\""
+
+
+GIT_ORIGIN_COMMAND = git --git-dir $$system_quote($$system_path($$ML_DIR/.git)) \
+--work-tree $$system_quote($$system_path($$ML_DIR/)) remote get-url origin
+
+GIT_ORIGIN = $$system($$GIT_ORIGIN_COMMAND)
+DEFINES += "GIT_ORIGIN=\"\\\"$$GIT_ORIGIN\\\"\""
+
+COMPILE_INFO = Compiled using Qt version: $$QT_VERSION ($$[QT_INSTALL_PREFIX] on host: \'$$QMAKE_HOST.name\'
+DEFINES += "COMPILE_INFO=\"\\\"$$COMPILE_INFO\\\"\""
+
 load(ml_functions.prf)
-
-
 

--- a/features/ml_config.prf
+++ b/features/ml_config.prf
@@ -3,7 +3,11 @@
 #configure directories
 ML_DIR=$$clean_path($${PWD}/..)
 ML_SRCDIR=$${ML_DIR}/cpp
-ML_BINDIR=$${ML_DIR}/bin
+standalone:!macx{
+    ML_BINDIR=$${ML_DIR}/bin/qt-mountainview/
+} else {
+    ML_BINDIR=$${ML_DIR}/bin
+}
 ML_PACKAGESDIR=$${ML_DIR}/packages
 ML_KRONDIR=$${ML_DIR}/kron
 

--- a/features/ml_config.prf
+++ b/features/ml_config.prf
@@ -3,13 +3,13 @@
 #configure directories
 ML_DIR=$$clean_path($${PWD}/..)
 ML_SRCDIR=$${ML_DIR}/cpp
-standalone:!macx{
-    ML_BINDIR=$${ML_DIR}/bin/qt-mountainview/
-} else {
-    ML_BINDIR=$${ML_DIR}/bin
-}
+ML_BINDIR=$${ML_DIR}/bin
+ML_STANDALONE_NAME=qt-mountainview-standalone
+ML_BINDIR_STANDALONE=$${ML_BINDIR}/$${ML_STANDALONE_NAME}
 ML_PACKAGESDIR=$${ML_DIR}/packages
 ML_KRONDIR=$${ML_DIR}/kron
+
+
 
 # Store git commit/repo origin/compile info in preprocessor directives.
 GIT_COMMIT_COMMAND = git --git-dir $$system_quote($$system_path($$ML_DIR/.git)) \

--- a/features/ml_config.prf
+++ b/features/ml_config.prf
@@ -1,4 +1,4 @@
-macx:CONFIG -= app_bundle
+# This feature is loaded for *all* subdirs by top-level .qmake.conf file
 
 #configure directories
 ML_DIR=$$clean_path($${PWD}/..)

--- a/features/ml_qtdeploylinux.prf
+++ b/features/ml_qtdeploylinux.prf
@@ -1,5 +1,3 @@
-#message("ml_qtdeploylinux.prf, called from $$_PRO_FILE_")
-
 # Plan: put qt-mountainview and mv.mp in bin folder, alongside Qt folder
 
 # Easiest way to deploy Qt shared libs on Linux is just to copy *all* the
@@ -35,7 +33,8 @@ QMAKE_LFLAGS += '-Wl,-rpath,\'\$$ORIGIN/$${ML_QTLIBS_SUBDIR}\''
 # preserve symlinks, permissions, etc.)
 
 QtDeploy.commands += mkdir -p $$ML_QTLIBS_INSTALL_DIR ;
-QtDeploy.commands += rsync -a --info=NAME $$[QT_INSTALL_LIBS]/*.so* $$ML_QTLIBS_INSTALL_DIR ;
+# exclude is a hackin lieu of actually figuring out which libs we need; this lib alone is >100MB
+QtDeploy.commands += rsync -a --exclude="*libQt5WebEngineCore*" --info=NAME $$[QT_INSTALL_LIBS]/*.so* $$ML_QTLIBS_INSTALL_DIR ;
 QtDeploy.commands += mkdir -p $$ML_QTPLUGINS_INSTALL_DIR ;
 QtDeploy.commands += rsync -a --info=NAME $$[QT_INSTALL_PLUGINS]/* $$ML_QTPLUGINS_INSTALL_DIR ;
 

--- a/features/ml_qtdeploylinux.prf
+++ b/features/ml_qtdeploylinux.prf
@@ -19,8 +19,8 @@ ML_QTLIBS_SUBDIR = Qt/lib
 ML_QTPLUGINS_SUBDIR = Qt/plugins
 
 # Set up full install paths
-ML_QTLIBS_INSTALL_DIR = $${ML_BINDIR}/$${ML_QTLIBS_SUBDIR}
-ML_QTPLUGINS_INSTALL_DIR = $${ML_BINDIR}/$${ML_QTPLUGINS_SUBDIR}
+ML_QTLIBS_INSTALL_DIR = $${ML_BINDIR_STANDALONE}/$${ML_QTLIBS_SUBDIR}
+ML_QTPLUGINS_INSTALL_DIR = $${ML_BINDIR_STANDALONE}/$${ML_QTPLUGINS_SUBDIR}
 
 # use RPATH to tell all binaries to search our Qt install first,
 # using special $ORIGIN directive to ld (man ld.so)

--- a/features/ml_qtdeploylinux.prf
+++ b/features/ml_qtdeploylinux.prf
@@ -1,0 +1,76 @@
+#message("ml_qtdeploylinux.prf, called from $$_PRO_FILE_")
+
+# Plan: put qt-mountainview and mv.mp in bin folder, alongside Qt folder
+
+# Easiest way to deploy Qt shared libs on Linux is just to copy *all* the
+# *.so files and links. (Some Qt libs have dependencies on other Qt libs,
+# and both Ubuntu 14.04 and 16.04 come with Qt5 installed, which means you
+# can't easily detect when you have not copied over all the libs or
+# plugins; this leads to using a mixture of libs from different releases.)
+#
+# NB: As of 5.5, the Qt plugin .so files expect the Qt shared libs to be at
+# a hardcoded relative location: "../../lib" (set via a RUNPATH on the plugin.so files),
+# so the libraries must be in a folder called 'lib', in the same directory as
+# the 'plugins' directory. It is also helpful to call the plugins folder
+# by its default name 'plugins' (otherwise would need to set this using
+# qt.conf):
+#
+# NB2: If you change the location of the plugins directory here, you must
+# also update the Resources/qt.conf file.
+ML_QTLIBS_SUBDIR = Qt/lib
+ML_QTPLUGINS_SUBDIR = Qt/plugins
+
+# Set up full install paths
+ML_QTLIBS_INSTALL_DIR = $${ML_BINDIR}/$${ML_QTLIBS_SUBDIR}
+ML_QTPLUGINS_INSTALL_DIR = $${ML_BINDIR}/$${ML_QTPLUGINS_SUBDIR}
+
+# use RPATH to tell all binaries to search our Qt install first,
+# using special $ORIGIN directive to ld (man ld.so)
+QMAKE_LFLAGS += '-Wl,-rpath,\'\$$ORIGIN/$${ML_QTLIBS_SUBDIR}\''
+
+# Create QtDeploy target to be built on 'make install'
+
+# Copy over Qt libs and plugins
+# (Use 'rsync' instead of 'cp' to avoid lots of unnecessary copying and to
+# preserve symlinks, permissions, etc.)
+
+QtDeploy.commands += mkdir -p $$ML_QTLIBS_INSTALL_DIR ;
+QtDeploy.commands += rsync -a --info=NAME $$[QT_INSTALL_LIBS]/*.so* $$ML_QTLIBS_INSTALL_DIR ;
+QtDeploy.commands += mkdir -p $$ML_QTPLUGINS_INSTALL_DIR ;
+QtDeploy.commands += rsync -a --info=NAME $$[QT_INSTALL_PLUGINS]/* $$ML_QTPLUGINS_INSTALL_DIR ;
+
+# Use Qt Resource System for the qt.conf file
+RESOURCES += \
+    $$ML_DIR/Resources/qtconf.qrc
+
+# Don't need this as mountainview does not use any 3rd-party libs. Leaving it here in case this changes
+#    # Remove any rpaths from our 3rd party libraries (since these 'pollute' the
+#    # library search path; e.g. libPythonQt typically has an rpath set to find Qt
+#    # libs at the compile location). Our libs will instead inherit the needed
+#    # search path from the executables. (Need to test for existence of chrpath first.)
+#    QtDeploy.commands += "command -v chrpath >/dev/null 2>&1 || { echo \"---> ---> \'chrpath\' command not found, install with \'apt-get install chrpath\'\" ; exit 1 ; } ;"
+#    QtDeploy.commands += "for lib in $${ML_LIB_INSTALL_DIR}/*.so*; do [ -f \$$lib ] || continue ; chrpath -d \$$lib; done ;"
+
+# Debug commands
+# message($$QtDeploy.commands)
+
+QtDeploy.path = / # dummy path (needed for QtDeploy to be a valid target)
+INSTALLS += QtDeploy
+
+# By default, Qmake includes the absolute path to the Qt libs used at
+# compile time, as an RPATH entry. We would like to suppress this,
+# which we can do by unsetting the QMAKE_RPATH variable:
+QMAKE_RPATH=
+
+# However this can break linking, since the linker uses -rpath entries to
+# resolve dependencies of shared libs. Fix it by passing the default libs
+# but **only for linking purposes**, (man ld, see '-rpath-link').
+QMAKE_LFLAGS += '-Wl,-rpath-link,$$[QT_INSTALL_LIBS]'
+
+# If all goes well (and you have the chrpath utility), you should see:
+#
+#   $ chrpath -l bin/linux/mountainview
+#   bin/linux/mountainview: RPATH=$$ORIGIN/Qt/lib
+
+# Let the user know that mountainview has been built to be used with a pre-deployed Qt:
+message('**Building $$TARGET to be used with a deployed Qt. Binaries may not work until you run \'make install\'**')

--- a/mountainview.pro
+++ b/mountainview.pro
@@ -58,7 +58,7 @@ standalone:unix{
     linux: {
         # standalone versions of mv and qt-mountainview are installed into ML_BINDIR_STANDALONE with correct linking and
         # Qt libs deployed by ml_qtdeploylinux feature. Here we just need to package them up.
-        QtDeploy.commands += "cd $${ML_BINDIR_STANDALONE} ; tar czvf $${ML_STANDALONE_NAME}-$${GIT_HASH}.tgz $${ML_STANDALONE_NAME} ; "
+        QtDeploy.commands += "cd $${ML_BINDIR_STANDALONE} ; tar czvf $${ML_STANDALONE_NAME}-linux-$${GIT_HASH}-Qt$${QT_VERSION}.tgz $${ML_STANDALONE_NAME} ; "
         QtDeploy.path = / # dummy path required for target to be valid
 	INSTALLS += QtDeploy
     }
@@ -68,7 +68,7 @@ standalone:unix{
         # Need to do this at top-level since we need to move mv.mp into qt-mountainview app bundle
         QtDeploy.commands += "cp $${ML_PACKAGESDIR}/mv/bin/mv.mp $${ML_BINDIR}/qt-mountainview.app/Contents/MacOS/ ;"
         QtDeploy.commands += "$$[QT_INSTALL_BINS]/macdeployqt $${ML_BINDIR}/qt-mountainview.app -always-overwrite -executable=$$ML_BINDIR/qt-mountainview.app/Contents/MacOS/mv.mp ;"
-        QtDeploy.commands += "cd $$ML_BINDIR ; ditto -c -k --sequesterRsrc --keepParent $$ML_BINDIR/qt-mountainview.app $${ML_STANDALONE_NAME}-$${GIT_HASH}.zip;"
+        QtDeploy.commands += "cd $$ML_BINDIR ; ditto -c -k --sequesterRsrc --keepParent $$ML_BINDIR/qt-mountainview.app $${ML_STANDALONE_NAME}-macOS-$${GIT_HASH}-Qt$${QT_VERSION}.zip;"
         QtDeploy.path = / # dummy path required for target to be valid
 
         INSTALLS += QtDeploy

--- a/mountainview.pro
+++ b/mountainview.pro
@@ -60,7 +60,8 @@ standalone:unix{
     macx: {
         # Need to do this at top-level since we need to move mv.mp into qt-mountainview app bundle
         QtDeploy.commands += "cp $${ML_PACKAGESDIR}/mv/bin/mv.mp $${ML_BINDIR}/qt-mountainview.app/Contents/MacOS/ ;"
-        QtDeploy.commands += "$$[QT_INSTALL_BINS]/macdeployqt $${ML_BINDIR}/qt-mountainview.app -always-overwrite -executable=$$ML_BINDIR/qt-mountainview.app/Contents/MacOS/mv.mp"
+        QtDeploy.commands += "$$[QT_INSTALL_BINS]/macdeployqt $${ML_BINDIR}/qt-mountainview.app -always-overwrite -executable=$$ML_BINDIR/qt-mountainview.app/Contents/MacOS/mv.mp ;"
+        QtDeploy.commands += "cd $$ML_BINDIR ; ditto -c -k --sequesterRsrc --keepParent $$ML_BINDIR/qt-mountainview.app qt-mountainview-standalone-$${GIT_HASH}.zip;"
         QtDeploy.path = / # dummy path required for target to be valid
 
         message(QtDeploy.commands=$$QtDeploy.commands)

--- a/mountainview.pro
+++ b/mountainview.pro
@@ -55,16 +55,22 @@ standalone:unix{
         error("Building standalone on $${QMAKE_HOST.os} requires Qt $${MAJ_REQ}.$${MIN_REQ} or greater, but Qt $$[QT_VERSION] was detected.")
     }
 
+    linux: {
+        # standalone versions of mv and qt-mountainview are installed into ML_BINDIR_STANDALONE with correct linking and
+        # Qt libs deployed by ml_qtdeploylinux feature. Here we just need to package them up.
+        QtDeploy.commands += "cd $${ML_BINDIR_STANDALONE} ; tar czvf $${ML_STANDALONE_NAME}-$${GIT_HASH}.tgz $${ML_STANDALONE_NAME} ; "
+        QtDeploy.path = / # dummy path required for target to be valid
+	INSTALLS += QtDeploy
+    }
     # (Linux standalone handled using ml_deployqtlinux feature)
 
     macx: {
         # Need to do this at top-level since we need to move mv.mp into qt-mountainview app bundle
         QtDeploy.commands += "cp $${ML_PACKAGESDIR}/mv/bin/mv.mp $${ML_BINDIR}/qt-mountainview.app/Contents/MacOS/ ;"
         QtDeploy.commands += "$$[QT_INSTALL_BINS]/macdeployqt $${ML_BINDIR}/qt-mountainview.app -always-overwrite -executable=$$ML_BINDIR/qt-mountainview.app/Contents/MacOS/mv.mp ;"
-        QtDeploy.commands += "cd $$ML_BINDIR ; ditto -c -k --sequesterRsrc --keepParent $$ML_BINDIR/qt-mountainview.app qt-mountainview-standalone-$${GIT_HASH}.zip;"
+        QtDeploy.commands += "cd $$ML_BINDIR ; ditto -c -k --sequesterRsrc --keepParent $$ML_BINDIR/qt-mountainview.app $${ML_STANDALONE_NAME}-$${GIT_HASH}.zip;"
         QtDeploy.path = / # dummy path required for target to be valid
 
-        message(QtDeploy.commands=$$QtDeploy.commands)
         INSTALLS += QtDeploy
     }
 }

--- a/mountainview.pro
+++ b/mountainview.pro
@@ -58,7 +58,7 @@ standalone:unix{
     linux: {
         # standalone versions of mv and qt-mountainview are installed into ML_BINDIR_STANDALONE with correct linking and
         # Qt libs deployed by ml_qtdeploylinux feature. Here we just need to package them up.
-        QtDeploy.commands += "cd $${ML_BINDIR_STANDALONE} ; tar czvf $${ML_STANDALONE_NAME}-linux-$${GIT_HASH}-Qt$${QT_VERSION}.tgz $${ML_STANDALONE_NAME} ; "
+        QtDeploy.commands += "cd $${ML_BINDIR} ; tar czvf $${ML_STANDALONE_NAME}-linux-$${GIT_HASH}-Qt$${QT_VERSION}.tgz $${ML_STANDALONE_NAME} ; "
         QtDeploy.path = / # dummy path required for target to be valid
 	INSTALLS += QtDeploy
     }

--- a/mountainview.pro
+++ b/mountainview.pro
@@ -55,15 +55,15 @@ standalone:unix{
         error("Building standalone on $${QMAKE_HOST.os} requires Qt $${MAJ_REQ}.$${MIN_REQ} or greater, but Qt $$[QT_VERSION] was detected.")
     }
 
+    # (Linux standalone handled using ml_deployqtlinux feature)
+
     macx: {
+        # Need to do this at top-level since we need to move mv.mp into qt-mountainview app bundle
         QtDeploy.commands += "cp $${ML_PACKAGESDIR}/mv/bin/mv.mp $${ML_BINDIR}/qt-mountainview.app/Contents/MacOS/ ;"
         QtDeploy.commands += "$$[QT_INSTALL_BINS]/macdeployqt $${ML_BINDIR}/qt-mountainview.app -always-overwrite -executable=$$ML_BINDIR/qt-mountainview.app/Contents/MacOS/mv.mp"
         QtDeploy.path = / # dummy path required for target to be valid
 
         message(QtDeploy.commands=$$QtDeploy.commands)
         INSTALLS += QtDeploy
-
-    } else {
-        error('Linux standalone mode not implemented yet')
     }
 }

--- a/packages/mv/mv.pro
+++ b/packages/mv/mv.pro
@@ -5,6 +5,12 @@ QT += qml
 CONFIG += c++11
 
 DESTDIR = bin
+standalone:!macx:{
+    include($$ML_DIR/cpp/installbin.pri)
+    CONFIG += ml_qtdeploylinux
+    # message(mv.mp INSTALLS: $$INSTALLS)
+    # message(mv.mp target.path: $$target.path)
+}
 OBJECTS_DIR = build
 MOC_DIR= build
 TARGET = mv.mp

--- a/packages/mv/mv.pro
+++ b/packages/mv/mv.pro
@@ -9,6 +9,7 @@ OBJECTS_DIR = build
 MOC_DIR= build
 TARGET = mv.mp
 TEMPLATE = app
+macx:CONFIG -= app_bundle
 
 #QMAKE_CXXFLAGS += -fopenmp
 #QMAKE_LFLAGS += -fopenmp

--- a/packages/mv/mv.pro
+++ b/packages/mv/mv.pro
@@ -5,12 +5,14 @@ QT += qml
 CONFIG += c++11
 
 DESTDIR = bin
+
+# linux standalone: install to top-level bin dir, where the Qt libs will be set up.
 standalone:!macx:{
-    include($$ML_DIR/cpp/installbin.pri)
+    target.path=$$ML_BINDIR
+    INSTALLS+=target
     CONFIG += ml_qtdeploylinux
-    # message(mv.mp INSTALLS: $$INSTALLS)
-    # message(mv.mp target.path: $$target.path)
 }
+
 OBJECTS_DIR = build
 MOC_DIR= build
 TARGET = mv.mp

--- a/packages/mv/mv.pro
+++ b/packages/mv/mv.pro
@@ -6,11 +6,11 @@ CONFIG += c++11
 
 DESTDIR = bin
 
-# linux standalone: install to top-level bin dir, where the Qt libs will be set up.
+# linux standalone: install alongside qt-mountainview, where the Qt libs will be set up.
 standalone:!macx:{
-    target.path=$$ML_BINDIR
-    INSTALLS+=target
     CONFIG += ml_qtdeploylinux
+    target.path=$${ML_BINDIR_STANDALONE}
+    INSTALLS+=target
 }
 
 OBJECTS_DIR = build


### PR DESCRIPTION
These commits create standalone, precompiled installations of **qt-mountainview** & **mv.mp** for Mac and Linux that can be run as a mountainlab-js package, without relying on a system install of Qt (or any other libraries). The executables are set up to use only an included copy of the Qt libs.

I also added a diagnostic message when running qt-mountainview to indicate which git commit was used to compile. This could be useful for debugging purposes if folks are using a binary that they didn't compile themselves.

On either mac or linux, you can build the standalone versions like so (NB: don't use the standard `./compile_components.sh` script):

```
cd /path/to/qt-mountainview
qmake -r CONFIG+=standalone
make; make install
```

Afterward, on Mac, you should see, in the `bin/` directory:
```$ ls -lh bin
total 22840
-rw-r--r--  1 tjd  staff    11M May 23 13:16 qt-mountainview-standalone-macOS-f4be5e7-Qt5.9.5.zip
drwxr-xr-x  3 tjd  staff    96B May 23 13:16 qt-mountainview.app
```
`qt-mountainview.app` is a normal Mac application bundle, and can even be run by double-clicking. However to pass arguments to the application, you need to call the actual executable, which is at:
`qt-mountainview.app/Contents/MacOS/qt-mountainview`. Users should create an alias or make sure that this is on your path somewhere.

```
$ find bin -maxdepth 4
bin
bin/qt-mountainview-standalone-macOS-f4be5e7-Qt5.9.5.zip
bin/qt-mountainview.app
bin/qt-mountainview.app/Contents
bin/qt-mountainview.app/Contents/MacOS
bin/qt-mountainview.app/Contents/MacOS/qt-mountainview
bin/qt-mountainview.app/Contents/MacOS/mv.mp
bin/qt-mountainview.app/Contents/PlugIns
bin/qt-mountainview.app/Contents/PlugIns/platforms
bin/qt-mountainview.app/Contents/PlugIns/printsupport
bin/qt-mountainview.app/Contents/PlugIns/bearer
bin/qt-mountainview.app/Contents/PlugIns/iconengines
bin/qt-mountainview.app/Contents/PlugIns/imageformats
bin/qt-mountainview.app/Contents/Resources
bin/qt-mountainview.app/Contents/Resources/qt.conf
bin/qt-mountainview.app/Contents/Resources/empty.lproj
bin/qt-mountainview.app/Contents/Frameworks
bin/qt-mountainview.app/Contents/Frameworks/QtPrintSupport.framework
bin/qt-mountainview.app/Contents/Frameworks/QtGui.framework
bin/qt-mountainview.app/Contents/Frameworks/QtCore.framework
bin/qt-mountainview.app/Contents/Frameworks/QtQml.framework
bin/qt-mountainview.app/Contents/Frameworks/QtWidgets.framework
bin/qt-mountainview.app/Contents/Frameworks/QtNetwork.framework
bin/qt-mountainview.app/Contents/Frameworks/QtSvg.framework
bin/qt-mountainview.app/Contents/Frameworks/QtConcurrent.framework
bin/qt-mountainview.app/Contents/Info.plist
bin/qt-mountainview.app/Contents/PkgInfo
```
The qt-mountainview.app should be placed under ~/.mountainlab/packages, and should be run from this location (this allows mountainlab to find the mv.* processors).

Likewise, on Linux:
```
$ find bin -maxdepth 3
bin
bin/qt-mountainview-standalone
bin/qt-mountainview-standalone/mv.mp
bin/qt-mountainview-standalone/Qt
bin/qt-mountainview-standalone/Qt/plugins
bin/qt-mountainview-standalone/Qt/lib
bin/qt-mountainview-standalone/qt-mountainview
bin/qt-mountainview-standalone-linux-f4be5e7-Qt5.9.4.tgz
```
The qt-mountainview-standalone folder should placed under ~/.mountainview/packages, and qt-mountainview should be run from this location (it should not be moved from this directory)

This has only been tested on MacOS 10.13 with Qt 5.9.5, and Ubuntu 16.05 with Qt 5.9.4. I'll try to upload some example binaries for testing.

If you don't add CONFIG+=standalone, then you should build mv.mp and qt-mountainview exactly as before (i.e. not standalone, not as a mac .app bundle, etc). The only change you would see would be the debug messages at runtime about Git commit version.