### PR TITLE
Rip out all cache expiration/duration stuff; use single temp dir

### DIFF
--- a/cpp/mlcommon/include/cachemanager/cachemanager.h
+++ b/cpp/mlcommon/include/cachemanager/cachemanager.h
@@ -23,25 +23,13 @@
 class CacheManagerPrivate;
 class CacheManager {
 public:
-    enum Duration {
-        ShortTerm,
-        LongTerm
-    };
-
     friend class CacheManagerPrivate;
     CacheManager();
     virtual ~CacheManager();
 
     void setLocalBasePath(const QString& path);
-    void setIntermediateFileFolder(const QString& folder);
-    QString makeLocalFile(const QString& file_name = "", Duration duration = ShortTerm);
-    QString makeIntermediateFile(const QString& file_name = "");
+    QString makeLocalFile(const QString& file_name = "");
     QString localTempPath();
-
-    void setTemporaryFileDuration(QString path, qint64 duration_sec);
-    void setTemporaryFileExpirePid(QString path, qint64 pid);
-    QString makeExpiringFile(QString file_name, qint64 duration_sec);
-    void removeExpiredFiles();
 
     void cleanUp();
 

--- a/cpp/mlcommon/src/mda/diskreadmda.cpp
+++ b/cpp/mlcommon/src/mda/diskreadmda.cpp
@@ -304,7 +304,7 @@ QString DiskReadMda::makePath() const
         return d->m_path;
     if (d->m_use_memory_mda) {
         QString checksum = compute_mda_checksum(d->m_memory_mda);
-        QString fname = CacheManager::globalInstance()->makeLocalFile(checksum + ".makePath.mda", CacheManager::ShortTerm);
+        QString fname = CacheManager::globalInstance()->makeLocalFile(checksum + ".makePath.mda");
         if (QFile::exists(fname))
             return fname;
         if (d->m_memory_mda.write64(fname + ".tmp")) {

--- a/cpp/mlcommon/src/mda/diskreadmda32.cpp
+++ b/cpp/mlcommon/src/mda/diskreadmda32.cpp
@@ -304,7 +304,7 @@ QString DiskReadMda32::makePath() const
         return d->m_path;
     if (d->m_use_memory_mda) {
         QString checksum = compute_mda_checksum(d->m_memory_mda);
-        QString fname = CacheManager::globalInstance()->makeLocalFile(checksum + ".makePath.mda", CacheManager::ShortTerm);
+        QString fname = CacheManager::globalInstance()->makeLocalFile(checksum + ".makePath.mda");
         if (QFile::exists(fname))
             return fname;
         if (d->m_memory_mda.write64(fname + ".tmp")) {

--- a/cpp/mlcommon/src/mda/mda.cpp
+++ b/cpp/mlcommon/src/mda/mda.cpp
@@ -317,7 +317,7 @@ bool Mda::write64(const char* path) const
 
 QByteArray Mda::toByteArray8() const
 {
-    QString path = CacheManager::globalInstance()->makeLocalFile("", CacheManager::ShortTerm);
+    QString path = CacheManager::globalInstance()->makeLocalFile("");
     write8(path);
     QByteArray ret = MLUtil::readByteArray(path);
     QFile::remove(path);
@@ -326,7 +326,7 @@ QByteArray Mda::toByteArray8() const
 
 QByteArray Mda::toByteArray32() const
 {
-    QString path = CacheManager::globalInstance()->makeLocalFile("", CacheManager::ShortTerm);
+    QString path = CacheManager::globalInstance()->makeLocalFile("");
     write32(path);
     QByteArray ret = MLUtil::readByteArray(path);
     QFile::remove(path);
@@ -335,7 +335,7 @@ QByteArray Mda::toByteArray32() const
 
 QByteArray Mda::toByteArray64() const
 {
-    QString path = CacheManager::globalInstance()->makeLocalFile("", CacheManager::ShortTerm);
+    QString path = CacheManager::globalInstance()->makeLocalFile("");
     write64(path);
     QByteArray ret = MLUtil::readByteArray(path);
     QFile::remove(path);
@@ -344,7 +344,7 @@ QByteArray Mda::toByteArray64() const
 
 bool Mda::fromByteArray(const QByteArray& X)
 {
-    QString path = CacheManager::globalInstance()->makeLocalFile("", CacheManager::ShortTerm);
+    QString path = CacheManager::globalInstance()->makeLocalFile("");
     MLUtil::writeByteArray(path, X);
     bool ret = this->read(path);
     QFile::remove(path);

--- a/cpp/mlcommon/src/mda/mda32.cpp
+++ b/cpp/mlcommon/src/mda/mda32.cpp
@@ -200,7 +200,7 @@ bool Mda32::write64(const char* path) const
 
 QByteArray Mda32::toByteArray8() const
 {
-    QString path = CacheManager::globalInstance()->makeLocalFile("", CacheManager::ShortTerm);
+    QString path = CacheManager::globalInstance()->makeLocalFile("");
     write8(path);
     QByteArray ret = MLUtil::readByteArray(path);
     QFile::remove(path);
@@ -209,7 +209,7 @@ QByteArray Mda32::toByteArray8() const
 
 QByteArray Mda32::toByteArray32() const
 {
-    QString path = CacheManager::globalInstance()->makeLocalFile("", CacheManager::ShortTerm);
+    QString path = CacheManager::globalInstance()->makeLocalFile("");
     write32(path);
     QByteArray ret = MLUtil::readByteArray(path);
     QFile::remove(path);
@@ -218,7 +218,7 @@ QByteArray Mda32::toByteArray32() const
 
 QByteArray Mda32::toByteArray64() const
 {
-    QString path = CacheManager::globalInstance()->makeLocalFile("", CacheManager::ShortTerm);
+    QString path = CacheManager::globalInstance()->makeLocalFile("");
     write64(path);
     QByteArray ret = MLUtil::readByteArray(path);
     QFile::remove(path);
@@ -227,7 +227,7 @@ QByteArray Mda32::toByteArray64() const
 
 bool Mda32::fromByteArray(const QByteArray& X)
 {
-    QString path = CacheManager::globalInstance()->makeLocalFile("", CacheManager::ShortTerm);
+    QString path = CacheManager::globalInstance()->makeLocalFile("");
     MLUtil::writeByteArray(path, X);
     bool ret = this->read(path);
     QFile::remove(path);

--- a/cpp/mlcommon/src/mda/remotereadmda.cpp
+++ b/cpp/mlcommon/src/mda/remotereadmda.cpp
@@ -442,7 +442,7 @@ QString RemoteReadMdaPrivate::download_chunk_at_index(int ii)
         return "";
     }
     QString file_name = m_info.checksum + "-" + QString("%1-%2").arg(m_download_chunk_size).arg(ii);
-    QString fname = CacheManager::globalInstance()->makeLocalFile(file_name, CacheManager::ShortTerm);
+    QString fname = CacheManager::globalInstance()->makeLocalFile(file_name);
     if (QFile::exists(fname))
         return fname;
     QString url = m_path;

--- a/cpp/mlcommon/src/mlnetwork/mlnetwork-old.cpp
+++ b/cpp/mlcommon/src/mlnetwork/mlnetwork-old.cpp
@@ -54,7 +54,7 @@ QString get_http_text_curl(const QString& url)
 #endif
         return "";
     }
-    QString tmp_fname = CacheManager::globalInstance()->makeLocalFile("", CacheManager::ShortTerm);
+    QString tmp_fname = CacheManager::globalInstance()->makeLocalFile("");
     QString cmd = QString("curl \"%1\" > %2").arg(url).arg(tmp_fname);
     int exit_code = system(cmd.toLatin1().data());
     if (exit_code != 0) {

--- a/cpp/mountainview/src/controlwidgets/mvexportcontrol/mvexportcontrol.cpp
+++ b/cpp/mountainview/src/controlwidgets/mvexportcontrol/mvexportcontrol.cpp
@@ -421,7 +421,6 @@ void MVExportControl::slot_open_prv_manager()
             errtask.error("Error writing .mv2 file: " + fname);
             return;
         }
-        CacheManager::globalInstance()->setTemporaryFileDuration(fname, 600);
     }
     int exit_code = system(("prv-gui " + fname).toUtf8().data());
     Q_UNUSED(exit_code)

--- a/cpp/mountainview/src/mountainviewmain.cpp
+++ b/cpp/mountainview/src/mountainviewmain.cpp
@@ -441,7 +441,6 @@ int main(int argc, char* argv[])
             mv2_fname = CacheManager::globalInstance()->makeLocalFile() + ".mv2";
             QString mv2_text = QJsonDocument(mv2).toJson();
             TextFile::write(mv2_fname, mv2_text);
-            CacheManager::globalInstance()->setTemporaryFileDuration(mv2_fname, 600);
         }
 
         if (!mv_fname.isEmpty()) {
@@ -1057,7 +1056,6 @@ void try_to_automatically_download_and_regenerate_prv_objects(QList<PrvRecord> p
             QString src_fname = CacheManager::globalInstance()->makeLocalFile() + ".tmp.prv";
             QString dst_fname = src_fname + ".recover";
             TextFile::write(src_fname, QJsonDocument(prv.original_object).toJson());
-            CacheManager::globalInstance()->setTemporaryFileDuration(src_fname, 600);
             QString cmd = QString("prv recover %1 %2").arg(src_fname).arg(dst_fname);
             system_call_keeping_gui_alive(cmd.toLatin1().data(), "Recovering " + prv.label);
             QFile::remove(src_fname);

--- a/cpp/mountainview/src/msv/contextmenuhandlers/clustercontextmenuhandler.cpp
+++ b/cpp/mountainview/src/msv/contextmenuhandlers/clustercontextmenuhandler.cpp
@@ -247,7 +247,6 @@ void MVClusterContextMenuHandler::slot_extract_selected_clusters()
     QJsonObject obj = this->mainWindow()->mvContext()->toMV2FileObject();
     QString json = QJsonDocument(obj).toJson();
     TextFile::write(tmp_fname, json);
-    CacheManager::globalInstance()->setTemporaryFileDuration(tmp_fname, 600);
     QString exe = qApp->applicationFilePath();
     QStringList args;
     QList<int> clusters = c->selectedClusters();

--- a/cpp/mvcommon/src/core/mountainprocessrunner.cpp
+++ b/cpp/mvcommon/src/core/mountainprocessrunner.cpp
@@ -327,7 +327,7 @@ QString MountainProcessRunnerPrivate::create_temporary_output_file_name(const QS
     }
 
     QString file_name = QString("%1_%2.tmp").arg(MLUtil::computeSha1SumOfString(str)).arg(parameter_name);
-    //QString ret = CacheManager::globalInstance()->makeRemoteFile(mlproxy_url, file_name, CacheManager::LongTerm);
-    QString ret = CacheManager::globalInstance()->makeLocalFile(file_name, CacheManager::LongTerm);
+    //QString ret = CacheManager::globalInstance()->makeRemoteFile(mlproxy_url, file_name);
+    QString ret = CacheManager::globalInstance()->makeLocalFile(file_name);
     return ret;
 }

--- a/cpp/mvcommon/src/prvmanagerdialog.cpp
+++ b/cpp/mvcommon/src/prvmanagerdialog.cpp
@@ -236,7 +236,6 @@ void PrvManagerDialogPrivate::ensure_local(QJsonObject prv_obj)
 {
     QString tmp_fname = CacheManager::globalInstance()->makeLocalFile(MLUtil::makeRandomId(10) + ".PrvManagerdlg.prv");
     TextFile::write(tmp_fname, QJsonDocument(prv_obj).toJson());
-    CacheManager::globalInstance()->setTemporaryFileDuration(tmp_fname, 600);
     QString cmd = "prv";
     QStringList args;
     args << "ensure-local" << tmp_fname;
@@ -256,7 +255,6 @@ void PrvManagerDialogPrivate::ensure_remote(QJsonObject prv_obj, QString server)
 {
     QString tmp_fname = CacheManager::globalInstance()->makeLocalFile(MLUtil::makeRandomId(10) + ".PrvManagerdlg.prv");
     TextFile::write(tmp_fname, QJsonDocument(prv_obj).toJson());
-    CacheManager::globalInstance()->setTemporaryFileDuration(tmp_fname, 600);
     QString cmd = "prv";
     QStringList args;
     args << "ensure-remote" << tmp_fname << "--server=" + server;

--- a/packages/mv/mda/diskreadmda.cpp
+++ b/packages/mv/mda/diskreadmda.cpp
@@ -314,26 +314,6 @@ QString DiskReadMda::makePath() const
     if (d->m_use_memory_mda) {
         qWarning() << "Cannot make path for memory mda because we are not using the cache";
         abort();
-        /*
-        QString checksum = compute_mda_checksum(d->m_memory_mda);
-        QString fname = CacheManager::globalInstance()->makeLocalFile(checksum + ".makePath.mda", CacheManager::ShortTerm);
-        if (QFile::exists(fname))
-            return fname;
-        if (d->m_memory_mda.write64(fname + ".tmp")) {
-            if (QFile::rename(fname + ".tmp", fname)) {
-                return fname;
-            }
-            else {
-                QFile::remove(fname + ".tmp");
-                return "";
-            }
-        }
-        else {
-            QFile::remove(fname);
-            QFile::remove(fname + ".tmp");
-            return "";
-        }
-        */
     }
     else if (d->m_use_concat) {
         QStringList list;

--- a/packages/mv/mda/diskreadmda32.cpp
+++ b/packages/mv/mda/diskreadmda32.cpp
@@ -314,26 +314,6 @@ QString DiskReadMda32::makePath() const
     if (d->m_use_memory_mda) {
         qWarning() << "Cannot make path for memory mda because we are not using the file cache. Aborting.";
         abort();
-        /*
-        QString checksum = compute_mda_checksum(d->m_memory_mda);
-        QString fname = CacheManager::globalInstance()->makeLocalFile(checksum + ".makePath.mda", CacheManager::ShortTerm);
-        if (QFile::exists(fname))
-            return fname;
-        if (d->m_memory_mda.write64(fname + ".tmp")) {
-            if (QFile::rename(fname + ".tmp", fname)) {
-                return fname;
-            }
-            else {
-                QFile::remove(fname + ".tmp");
-                return "";
-            }
-        }
-        else {
-            QFile::remove(fname);
-            QFile::remove(fname + ".tmp");
-            return "";
-        }
-        */
     }
     else if (d->m_use_concat) {
         QStringList list;


### PR DESCRIPTION
Remove temp dir clean up code.

This is a pretty extreme solution to #8 .

Could be viable, maybe just will leave extra short-term temp files around.